### PR TITLE
fix build on linux

### DIFF
--- a/jb_plugin_base/Utils/MessageOfTheDay.h
+++ b/jb_plugin_base/Utils/MessageOfTheDay.h
@@ -105,14 +105,16 @@ public:
 
                 if (!update.isVoid())
                 {
-                    int64_t updateVersion = static_cast<juce::int64>(update.getProperty ("Version", static_cast<juce::int64>(currentPluginVersion)));
+                    int64_t updateVersion = static_cast<juce::int64> (update.getProperty ("Version", static_cast<juce::int64> (currentPluginVersion)));
+
                     if (updateVersion > currentPluginVersion && update.hasProperty ("Text") && update.hasProperty ("Link"))
                         messages.updateMessage = makeMessage (updateVersion, update);
                 }
 
                 if (!general.isVoid())
                 {
-                    int generalMessageVersion = static_cast<juce::int64>(general.getProperty ("Version", static_cast<juce::int64>(lastVersion)));
+                    int64_t generalMessageVersion = static_cast<juce::int64> (general.getProperty ("Version", static_cast<juce::int64> (lastVersion)));
+
                     if (generalMessageVersion > lastVersion && general.hasProperty ("Text"))
                         messages.generalMessage = makeMessage (generalMessageVersion, general);
                 }

--- a/jb_plugin_base/Utils/MessageOfTheDay.h
+++ b/jb_plugin_base/Utils/MessageOfTheDay.h
@@ -105,14 +105,14 @@ public:
 
                 if (!update.isVoid())
                 {
-                    int64_t updateVersion = update.getProperty ("Version", currentPluginVersion);
+                    int64_t updateVersion = static_cast<juce::int64>(update.getProperty ("Version", static_cast<juce::int64>(currentPluginVersion)));
                     if (updateVersion > currentPluginVersion && update.hasProperty ("Text") && update.hasProperty ("Link"))
                         messages.updateMessage = makeMessage (updateVersion, update);
                 }
 
                 if (!general.isVoid())
                 {
-                    int generalMessageVersion = general.getProperty ("Version", lastVersion);
+                    int generalMessageVersion = static_cast<juce::int64>(general.getProperty ("Version", static_cast<juce::int64>(lastVersion)));
                     if (generalMessageVersion > lastVersion && general.hasProperty ("Text"))
                         messages.generalMessage = makeMessage (generalMessageVersion, general);
                 }


### PR DESCRIPTION
This seems to fix the build issue I was having mentioned in the issue https://github.com/JanosGit/Schrammel_OJD/issues/40

The build of Schrammel_OJD still fails overall with this error, but at-least this part of the problem is fixed.

```
/usr/bin/ld: BinaryResources/libEmbeddedBinaryData.a(BinaryData1.cpp.o): warning: relocation against `_ZN10BinaryData8knob_svgE' in read-only section `.text'
/usr/bin/ld: libjb_git_version-OJD-VST3.a(gitVersion.cpp.o): relocation R_X86_64_PC32 against symbol `_ZN11ProjectInfo3Git3tagB5cxx11E' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/OJD-VST3_VST3.dir/build.make:247: OJD-VST3_artefacts/Release/VST3/OJD.vst3/Contents/x86_64-linux/OJD.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:307: CMakeFiles/OJD-VST3_VST3.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```